### PR TITLE
Adjust calls to DBus to reflect current KWin API

### DIFF
--- a/kwin.el
+++ b/kwin.el
@@ -76,12 +76,12 @@ The following keys are bound in this minor mode:
 
 (defun kwin-send-file (path)
   "Sends the path to KWin, tells it to load the file and connects the stdout and stderr to the inf-kwin buffer."
-  (lexical-let* ((script-id (dbus-call-method :session "org.kde.kwin.Scripting" "/Scripting" "org.kde.kwin.Scripting" "loadScript" path))
+  (lexical-let* ((script-id (dbus-call-method :session "org.kde.KWin" "/Scripting" "org.kde.kwin.Scripting" "loadScript" path))
          (script-path (concat "/" (number-to-string script-id)))
          (dbus-handles nil)             ; TODO: unregister these
          (start-time (current-time)))
     ;; Register the signals for stdout/stderr
-    (flet ((register-output (method handler) (dbus-register-signal :session "org.kde.kwin.Scripting" script-path "org.kde.kwin.Scripting" method handler)))
+    (flet ((register-output (method handler) (dbus-register-signal :session "org.kde.KWin" script-path "org.kde.kwin.Scripting" method handler)))
       (setq dbus-handles (list (register-output "print" (lambda (stdout) (kwin-write-to-output :stdout stdout script-id)))
                                (register-output "printError" (lambda (stderr) (kwin-write-to-output :stderr stderr script-id))))))
 
@@ -90,7 +90,7 @@ The following keys are bound in this minor mode:
     ;; connect isn't captured here, so we don't do cleanup... yet.
     ;; Apparently, the output isn't displayed twice even with the same
     ;; script id reused, so we should be fine.
-    (dbus-call-method-asynchronously :session "org.kde.kwin.Scripting" script-path "org.kde.kwin.Scripting" "run"
+    (dbus-call-method-asynchronously :session "org.kde.KWin" script-path "org.kde.kwin.Scripting" "run"
                                      (lambda (&rest args)
                                        
                                        ;; Only report if the script


### PR DESCRIPTION
The API has changed somewhen around KDE 4.8 If I understood correctly. The previous code would yield an error message from DBus. 